### PR TITLE
added dialog component

### DIFF
--- a/src/lib/components/ui/dialog.svelte
+++ b/src/lib/components/ui/dialog.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import { createEventDispatcher, onMount } from 'svelte';
+	import { fade, scale } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
+
+	const dispatch = createEventDispatcher();
+
+	let { 
+		open = $bindable(false), 
+		closeOnEscape = true,
+		closeOnOutsideClick = true,
+		className = ''
+	} = $props();
+
+	function handleClose() {
+		if (open) {
+			open = false;
+			dispatch('close');
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (closeOnEscape && event.key === 'Escape' && open) {
+			handleClose();
+		}
+	}
+
+	function handleOutsideClick(event: MouseEvent) {
+		if (closeOnOutsideClick && event.target === event.currentTarget && open) {
+			handleClose();
+		}
+	}
+
+	// Manage keydown listeners
+	$effect(() => {
+		if (open) {
+			document.addEventListener('keydown', handleKeydown);
+		} else {
+			document.removeEventListener('keydown', handleKeydown);
+		}
+	});
+
+	onMount(() => {
+		return () => {
+			document.removeEventListener('keydown', handleKeydown);
+		};
+	});
+</script>
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm"
+		onclick={handleOutsideClick}
+		transition:fade={{ duration: 200 }}
+	>
+		<div
+			class={cn(
+				"fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+				className
+			)}
+			role="dialog"
+			aria-modal="true"
+			transition:scale={{ duration: 300, start: 0.95, opacity: 0, easing: cubicOut }}
+		>
+			<slot {handleClose} />
+		</div>
+	</div>
+{/if} 

--- a/src/lib/components/ui/dialog/dialog-close.svelte
+++ b/src/lib/components/ui/dialog/dialog-close.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import { createEventDispatcher } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+	
+	const props = $props<{
+		size?: 'sm' | 'default';
+		className?: string;
+		onclick?: () => void;
+	}>();
+
+	// Use local state instead of trying to modify props
+	let size = $derived(props.size || 'default') as 'sm' | 'default';
+	let className = $derived(props.className || '');
+
+	const sizeClass = {
+		sm: 'h-5 w-5',
+		default: 'h-6 w-6'
+	};
+
+	function handleClick() {
+		dispatch('click');
+        return props.onclick?.();
+	}
+</script>
+
+<button
+	type="button"
+	class={cn(
+		'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity',
+		'hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+		className
+	)}
+	aria-label="Close"
+	onclick={handleClick}
+>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		class={cn(sizeClass[size])}
+	>
+		<path d="M18 6 6 18" />
+		<path d="m6 6 12 12" />
+	</svg>
+</button> 

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+</script>
+
+<div class={cn('py-4', $$props.class)} {...$$restProps}>
+	<slot />
+</div> 

--- a/src/lib/components/ui/dialog/dialog-description.svelte
+++ b/src/lib/components/ui/dialog/dialog-description.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+</script>
+
+<p class={cn('text-sm text-muted-foreground', $$props.class)} {...$$restProps}>
+	<slot />
+</p> 

--- a/src/lib/components/ui/dialog/dialog-footer.svelte
+++ b/src/lib/components/ui/dialog/dialog-footer.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+</script>
+
+<div class={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', $$props.class)} {...$$restProps}>
+	<slot />
+</div> 

--- a/src/lib/components/ui/dialog/dialog-header.svelte
+++ b/src/lib/components/ui/dialog/dialog-header.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+</script>
+
+<div class={cn('flex flex-col space-y-1.5 text-left', $$props.class)} {...$$restProps}>
+	<slot />
+</div> 

--- a/src/lib/components/ui/dialog/dialog-title.svelte
+++ b/src/lib/components/ui/dialog/dialog-title.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+</script>
+
+<h2 class={cn('text-lg font-semibold leading-none tracking-tight', $$props.class)} {...$$restProps}>
+	<slot />
+</h2> 

--- a/src/lib/components/ui/dialog/index.ts
+++ b/src/lib/components/ui/dialog/index.ts
@@ -1,0 +1,17 @@
+import Dialog from '../dialog.svelte';
+import DialogHeader from './dialog-header.svelte';
+import DialogContent from './dialog-content.svelte';
+import DialogFooter from './dialog-footer.svelte';
+import DialogTitle from './dialog-title.svelte';
+import DialogDescription from './dialog-description.svelte';
+import DialogClose from './dialog-close.svelte';
+
+export {
+	Dialog,
+	DialogHeader,
+	DialogContent,
+	DialogFooter,
+	DialogTitle,
+	DialogDescription,
+	DialogClose
+}; 

--- a/src/routes/components/+page.svelte
+++ b/src/routes/components/+page.svelte
@@ -10,8 +10,20 @@
 		CardContent,
 		CardFooter
 	} from '$lib/components/ui/card/index';
+	import {
+		Dialog,
+		DialogHeader,
+		DialogTitle,
+		DialogDescription,
+		DialogContent,
+		DialogFooter,
+		DialogClose
+	} from '$lib/components/ui/dialog/index';
 	import { toasts } from '$lib/stores/toast-store';
 	import { Check, X, AlertCircle, Info, AlertTriangle } from 'lucide-svelte';
+
+	let basicDialogOpen = false;
+	let formDialogOpen = false;
 </script>
 
 <div class="container mx-auto px-4 py-12 sm:px-6">
@@ -104,31 +116,85 @@
 				</div>
 			</div>
 
+			<!-- Dialogs -->
+			<div class="space-y-4">
+				<h2 class="text-xl font-semibold">Dialogs</h2>
+				<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+					<Button onclick={() => (basicDialogOpen = true)}>Open Basic Dialog</Button>
+					<Button onclick={() => (formDialogOpen = true)}>Open Form Dialog</Button>
+				</div>
+
+				<!-- Basic Dialog -->
+				<Dialog bind:open={basicDialogOpen}>
+					<DialogClose onclick={() => (basicDialogOpen = false)} />
+					<DialogHeader>
+						<DialogTitle>Dialog Title</DialogTitle>
+						<DialogDescription>A simple dialog with basic content.</DialogDescription>
+					</DialogHeader>
+					<DialogContent>
+						<p>
+							This is a basic dialog example. Dialogs are useful for displaying content that requires
+							user attention or interaction.
+						</p>
+					</DialogContent>
+					<DialogFooter>
+						<Button variant="outline" onclick={() => (basicDialogOpen = false)}>Cancel</Button>
+						<Button onclick={() => (basicDialogOpen = false)}>Confirm</Button>
+					</DialogFooter>
+				</Dialog>
+
+				<!-- Form Dialog -->
+				<Dialog bind:open={formDialogOpen}>
+					<DialogClose onclick={() => (formDialogOpen = false)} />
+					<DialogHeader>
+						<DialogTitle>Edit Profile</DialogTitle>
+						<DialogDescription>Make changes to your profile information.</DialogDescription>
+					</DialogHeader>
+					<DialogContent>
+						<div class="grid gap-4">
+							<FormField id="dialog-name" label="Name">
+								<Input id="dialog-name" placeholder="Enter your name" />
+							</FormField>
+							<FormField id="dialog-email" label="Email">
+								<Input id="dialog-email" type="email" placeholder="Enter your email" />
+							</FormField>
+						</div>
+					</DialogContent>
+					<DialogFooter>
+						<Button variant="outline" onclick={() => (formDialogOpen = false)}>Cancel</Button>
+						<Button onclick={() => {
+							toasts.success('Profile updated', 'Your profile has been updated successfully.');
+							formDialogOpen = false;
+						}}>Save Changes</Button>
+					</DialogFooter>
+				</Dialog>
+			</div>
+
 			<!-- Toast Notifications -->
 			<div class="space-y-4">
 				<h2 class="text-xl font-semibold">Toast Notifications</h2>
 				<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-2">
 					<Button
 						variant="default"
-						on:click={() => toasts.success('Success!', 'Operation completed successfully.')}
+						onclick={() => toasts.success('Success!', 'Operation completed successfully.')}
 					>
 						<Check class="mr-2 h-4 w-4" /> Show Success Toast
 					</Button>
 					<Button
 						variant="destructive"
-						on:click={() => toasts.error('Error!', 'Something went wrong.')}
+						onclick={() => toasts.error('Error!', 'Something went wrong.')}
 					>
 						<X class="mr-2 h-4 w-4" /> Show Error Toast
 					</Button>
 					<Button
 						variant="secondary"
-						on:click={() => toasts.info('Information', 'This is some useful information.')}
+						onclick={() => toasts.info('Information', 'This is some useful information.')}
 					>
 						<Info class="mr-2 h-4 w-4" /> Show Info Toast
 					</Button>
 					<Button
 						variant="outline"
-						on:click={() => toasts.warning('Warning', 'Proceed with caution.')}
+						onclick={() => toasts.warning('Warning', 'Proceed with caution.')}
 					>
 						<AlertTriangle class="mr-2 h-4 w-4" /> Show Warning Toast
 					</Button>


### PR DESCRIPTION
This pull request introduces a new reusable `Dialog` component system in Svelte, including several subcomponents for modular dialog construction and examples of its usage. The changes enhance the UI library by adding a flexible, accessible dialog implementation and integrating it into the components page.

### New Dialog Component System

* **Core Dialog Component**: Added a new `Dialog` component in `src/lib/components/ui/dialog.svelte` with features like `open` state binding, close-on-escape, and close-on-outside-click functionality. It uses Svelte transitions (`fade`, `scale`) and event dispatching for interactivity.
* **Subcomponents**:
  - [`DialogClose`](diffhunk://#diff-590a0f28614d0a268d45e9b5b9198c5c8a6865c11fe4ee665917637775b681d5R1-R51): A close button with customizable size and styles, dispatching a `click` event.
  - [`DialogContent`](diffhunk://#diff-3f74ce6642c874a04b3bb71f3eaf2e60913022304ec877b7f993784d3c469abdR1-R7): A wrapper for dialog content with padding.
  - [`DialogDescription`](diffhunk://#diff-0520e34cd7b54dfb4cf97cb0563b76708616dcbbdfdbb26445dfaa9a3b49a270R1-R7): A styled paragraph for dialog descriptions.
  - [`DialogFooter`](diffhunk://#diff-382ef1c3bd3e68ffba4e55fa7c5e0861a8ecc8a036a60ac005d1f49d782f5269R1-R7): A footer section with responsive layout.
  - [`DialogHeader`](diffhunk://#diff-46db1c0b76f414d372f9c609dc149a76145cfc0463463034b817a41f500a4f9bR1-R7): A header section for titles and descriptions.
  - [`DialogTitle`](diffhunk://#diff-10bebaa28a58f3a9d2ae42d57e46330b53a5169d22807244d1106df7c69d8c75R1-R7): A styled heading for dialog titles.
* **Exports**: Added an `index.ts` file to export the `Dialog` and its subcomponents for easy import.

### Integration and Examples

* **Components Page**: Integrated the `Dialog` system into `src/routes/components/+page.svelte`. Added two examples:
  - A basic dialog with static content.
  - A form dialog for editing profile information, with form fields and toast notifications on save. [[1]](diffhunk://#diff-44a8d5a97281fd53faa4a2042bfbe70df1730de3d32f04a86a9db939523c3b01R13-R26) [[2]](diffhunk://#diff-44a8d5a97281fd53faa4a2042bfbe70df1730de3d32f04a86a9db939523c3b01R119-R197)