### PR TITLE
feat(deploy): notify Discord via SvelteKit API route on Netlify deploy success

### DIFF
--- a/src/routes/api/netlify-webhook/+server.ts
+++ b/src/routes/api/netlify-webhook/+server.ts
@@ -1,16 +1,19 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { DISCORD_WEBHOOK_URL } from '$env/static/private';
 
-// health check
+// Healthcheck
 export const GET: RequestHandler = async () => {
-	return new Response(JSON.stringify('Netlify webhook is working!'), { 
-		status: 200, 
-		headers: { 'Content-Type': 'application/json' } 
+	return new Response(JSON.stringify('Netlify webhook is working!'), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' }
 	});
 };
 
+// Handle Netlify webhook
 export const POST: RequestHandler = async ({ request }) => {
 	const formData = await request.formData();
+
+	console.log('Received Netlify webhook payload:', [...formData.entries()]);
 
 	const deploy_url = formData.get('deploy_url') as string;
 	const name = formData.get('name') as string;
@@ -20,19 +23,18 @@ export const POST: RequestHandler = async ({ request }) => {
 		return new Response('Invalid payload', { status: 400 });
 	}
 
-	const discordWebhook = DISCORD_WEBHOOK_URL;
-
 	const message = {
 		content: `✅ **Netlify Deploy Succeeded**\n🔗 ${deploy_url}\n📦 Site: ${name}\n🌿 Branch: ${branch}`
 	};
 
-	const res = await fetch(discordWebhook, {
+	const res = await fetch(DISCORD_WEBHOOK_URL, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify(message)
 	});
 
 	if (!res.ok) {
+		console.error('Failed to send to Discord', await res.text());
 		return new Response('Failed to notify Discord', { status: 500 });
 	}
 

--- a/src/routes/api/netlify-webhook/+server.ts
+++ b/src/routes/api/netlify-webhook/+server.ts
@@ -3,21 +3,27 @@ import { DISCORD_WEBHOOK_URL } from '$env/static/private';
 
 // healthcheck
 export const GET: RequestHandler = async () => {
-	return new Response(JSON.stringify('Netlify webhook is working!'), { status: 200, headers: { 'Content-Type': 'application/json' } });
+	return new Response(JSON.stringify('Netlify webhook is working!'), { 
+		status: 200, 
+		headers: { 'Content-Type': 'application/json' } 
+	});
 };
 
 export const POST: RequestHandler = async ({ request }) => {
-	const payload = await request.json();
+	const formData = await request.formData();
 
-	if (!payload || !payload.deploy_url || !payload.name || !payload.branch) {
+	const deploy_url = formData.get('deploy_url') as string;
+	const name = formData.get('name') as string;
+	const branch = formData.get('branch') as string;
+
+	if (!deploy_url || !name || !branch) {
 		return new Response('Invalid payload', { status: 400 });
 	}
 
-	// https://discordapp.com/api/webhooks/<your_webhook_here>
-	const discordWebhook = DISCORD_WEBHOOK_URL
+	const discordWebhook = DISCORD_WEBHOOK_URL;
 
 	const message = {
-		content: `✅ **Netlify Deploy Succeeded**\n🔗 ${payload.deploy_url}\n📦 Site: ${payload.name}\n🌿 Branch: ${payload.branch}`
+		content: `✅ **Netlify Deploy Succeeded**\n🔗 ${deploy_url}\n📦 Site: ${name}\n🌿 Branch: ${branch}`
 	};
 
 	const res = await fetch(discordWebhook, {

--- a/src/routes/api/netlify-webhook/+server.ts
+++ b/src/routes/api/netlify-webhook/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { DISCORD_WEBHOOK_URL } from '$env/static/private';
 
-// Healthcheck
+// Health check for the webhook
 export const GET: RequestHandler = async () => {
 	return new Response(JSON.stringify('Netlify webhook is working!'), {
 		status: 200,

--- a/src/routes/api/netlify-webhook/+server.ts
+++ b/src/routes/api/netlify-webhook/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { DISCORD_WEBHOOK_URL } from '$env/static/private';
 
-// health check
+// healthcheck
 export const GET: RequestHandler = async () => {
 	return new Response(JSON.stringify('Netlify webhook is working!'), { status: 200, headers: { 'Content-Type': 'application/json' } });
 };

--- a/src/routes/api/netlify-webhook/+server.ts
+++ b/src/routes/api/netlify-webhook/+server.ts
@@ -1,0 +1,34 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { DISCORD_WEBHOOK_URL } from '$env/static/private';
+
+// health check
+export const GET: RequestHandler = async () => {
+	return new Response(JSON.stringify('Netlify webhook is working!'), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+	const payload = await request.json();
+
+	if (!payload || !payload.deploy_url || !payload.name || !payload.branch) {
+		return new Response('Invalid payload', { status: 400 });
+	}
+
+	// https://discordapp.com/api/webhooks/<your_webhook_here>
+	const discordWebhook = DISCORD_WEBHOOK_URL
+
+	const message = {
+		content: `✅ **Netlify Deploy Succeeded**\n🔗 ${payload.deploy_url}\n📦 Site: ${payload.name}\n🌿 Branch: ${payload.branch}`
+	};
+
+	const res = await fetch(discordWebhook, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(message)
+	});
+
+	if (!res.ok) {
+		return new Response('Failed to notify Discord', { status: 500 });
+	}
+
+	return new Response('Notification sent to Discord!', { status: 200 });
+};

--- a/src/routes/api/netlify-webhook/+server.ts
+++ b/src/routes/api/netlify-webhook/+server.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { DISCORD_WEBHOOK_URL } from '$env/static/private';
 
-// healthcheck
+// health check
 export const GET: RequestHandler = async () => {
 	return new Response(JSON.stringify('Netlify webhook is working!'), { 
 		status: 200, 


### PR DESCRIPTION
### 🚀 Pull Request: Notify Discord on Netlify Deploy

**Summary:**
This PR introduces a SvelteKit API route (`/api/netlify-webhook`) that listens for Netlify deploy success events and forwards them to a Discord channel via a webhook.

---

### ✨ Features

- New endpoint: `POST /api/netlify-webhook`
- Reads `DISCORD_WEBHOOK_URL` from `.env`
- Sends a simple deploy summary to Discord:
  - Site name
  - Branch name
  - Deploy preview URL

---

### 🔒 Environment Variable

Add this to your `.env`:

```env
DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
```

---

### 🛠️ How to Use

1. Deploy your SvelteKit app
2. Set up a Netlify **Outgoing Webhook** pointing to:
   ```
   https://ui.ibrahimraimi.com/api/netlify-webhook
   ```
3. Trigger a deploy — a Discord notification will follow 🎉

---

### ✅ Checklist

- [x] API route implemented and tested
- [x] .env setup documented
- [x] Discord webhook format tested
- [x] Netlify-compatible