### PR TITLE
refactor: redesigned button and switched to Svelte 5 reccommended syntax

### DIFF
--- a/src/lib/components/ui/button/Button.svelte
+++ b/src/lib/components/ui/button/Button.svelte
@@ -1,66 +1,58 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	import { type Snippet } from 'svelte';
+	import type { Snippet } from 'svelte';
+	
+ interface Props{
+	type?: 'button' | 'submit' | 'reset';
+	variant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
+	size?: 'default' | 'sm' | 'lg' | 'icon';
+	className?: string;
+	loading?: boolean;
+	disabled?: boolean;
+	children?: Snippet;
+ }
 
-	type buttonType = 'button' | 'submit' | 'reset';
-	type buttonVariant = 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
-	type buttonSize = 'default' | 'sm' | 'lg' | 'icon';
+ let {
+	type = 'button',
+	variant = 'default',
+	size = 'default',
+	className = '',
+	loading = false,
+	disabled = false,
+	children
+ }: Props = $props();
 
-	let {
-		children,
-		type = 'button',
-		variant = 'default',
-		size = 'default',
-		disabled = $bindable(false),
-		loading = $bindable(false),
-		class: className = '',
-
-		...restProps
-	}: {
-		children: Snippet;
-		type?: buttonType;
-		variant?: buttonVariant;
-		size?: buttonSize;
-		disabled?: boolean;
-		loading?: boolean;
-		class?: string;
-		[key: string]: any;
-	} = $props();
-
-	const buttonId = $props.id();
 	const variantClassMap = {
 		default: 'bg-primary text-primary-foreground hover:opacity-90',
 		destructive: 'bg-destructive text-destructive-foreground hover:opacity-90',
-		outline: 'border border-input bg-transparent hover:bg-accent hover:text-accent-foreground',
+		outline: 'border-2 border-input bg-transparent hover:bg-accent hover:text-accent-foreground',
 		secondary: 'bg-secondary text-secondary-foreground hover:opacity-80',
 		ghost: 'hover:bg-accent hover:text-accent-foreground',
 		link: 'text-primary underline-offset-4 hover:underline'
-	};
+	} as const;
 
 	const sizeClassMap = {
-		default: 'h-10 px-4 py-2',
-		sm: 'h-9 rounded-md px-3',
-		lg: 'h-11 rounded-md px-8',
-		icon: 'h-10 w-10'
-	};
+		default: 'h-12 px-6 py-3 text-base',
+		sm: 'h-10 px-4 py-2 text-sm',
+		lg: 'h-14 px-8 py-4 text-lg',
+		icon: 'h-12 w-12 p-3'
+	} as const;
 </script>
 
 <button
-	id={buttonId}
 	{type}
+	{disabled}
 	class={cn(
-		'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors',
-		'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+		'inline-flex items-center justify-center rounded-lg font-medium transition-all duration-200',
+		'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 		'disabled:pointer-events-none disabled:opacity-50',
 		variantClassMap[variant],
 		sizeClassMap[size],
 		className
 	)}
-	{disabled}
-	{...restProps}
 >
 	{#if loading}
-		<span class="mr-2 animate-spin">&#9696;</span>
+	<span class="mr-2 animate-spin">&#9696;</span>
 	{/if}
-	{@render children()}
+	{@render children?.()}
 </button>

--- a/src/lib/components/ui/button/Button.svelte
+++ b/src/lib/components/ui/button/Button.svelte
@@ -10,6 +10,7 @@
 	loading?: boolean;
 	disabled?: boolean;
 	children?: Snippet;
+	[key: string]: any;
  }
 
  let {
@@ -19,7 +20,8 @@
 	className = '',
 	loading = false,
 	disabled = false,
-	children
+	children,
+	...restProps
  }: Props = $props();
 
 	const variantClassMap = {
@@ -42,6 +44,7 @@
 <button
 	{type}
 	{disabled}
+	{...restProps}	
 	class={cn(
 		'inline-flex items-center justify-center rounded-lg font-medium transition-all duration-200',
 		'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',

--- a/src/lib/components/ui/button/Button.svelte
+++ b/src/lib/components/ui/button/Button.svelte
@@ -46,9 +46,9 @@
 	{disabled}
 	{...restProps}	
 	class={cn(
-		'inline-flex items-center justify-center rounded-lg font-medium transition-all duration-200',
+		'inline-flex items-center justify-center rounded-lg font-medium transition-all duration-200 cursor-pointer',
 		'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-		'disabled:pointer-events-none disabled:opacity-50',
+		'disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed',
 		variantClassMap[variant],
 		sizeClassMap[size],
 		className

--- a/src/lib/components/ui/button/Button.svelte
+++ b/src/lib/components/ui/button/Button.svelte
@@ -7,6 +7,7 @@
 	variant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
 	size?: 'default' | 'sm' | 'lg' | 'icon';
 	className?: string;
+	class?: string;
 	loading?: boolean;
 	disabled?: boolean;
 	children?: Snippet;
@@ -18,11 +19,14 @@
 	variant = 'default',
 	size = 'default',
 	className = '',
+	class: userClass = '',
 	loading = false,
 	disabled = false,
 	children,
 	...restProps
  }: Props = $props();
+
+ const combinedClass = userClass || className;
 
 	const variantClassMap = {
 		default: 'bg-primary text-primary-foreground hover:opacity-90',
@@ -51,7 +55,7 @@
 		'disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed',
 		variantClassMap[variant],
 		sizeClassMap[size],
-		className
+		combinedClass
 	)}
 >
 	{#if loading}

--- a/src/routes/(app)/components/+page.svelte
+++ b/src/routes/(app)/components/+page.svelte
@@ -25,7 +25,7 @@
 			<div class="space-y-4">
 				<h2 class="text-xl font-semibold">Buttons</h2>
 				<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
-					<Button onpress={() => console.log('testing default')}>Default</Button>
+					<Button onclick={() => console.log('testing default')}>Default</Button>
 					<Button variant="destructive">Destructive</Button>
 					<Button variant="outline">Outline</Button>
 					<Button variant="secondary">Secondary</Button>


### PR DESCRIPTION
This pull request refactors the `Button` component in `src/lib/components/ui/button/Button.svelte` to improve type safety, enhance styling, and simplify the API. It also updates the usage of the `Button` component in `src/routes/(app)/components/+page.svelte` to reflect these changes.

### Refactoring and API Improvements for `Button` Component:

* Replaced multiple `type` definitions (`buttonType`, `buttonVariant`, `buttonSize`) with a single `Props` interface for better type organization and extensibility. (`[src/lib/components/ui/button/Button.svelteL3-R57](diffhunk://#diff-a363cec7b0813af3b36ed98f1afc7d18d89df4c822356be440fde38910783ccaL3-R57)`)
* Simplified the destructuring of props by directly using the `Props` interface and removed redundant `$bindable` and `...restProps` handling. (`[src/lib/components/ui/button/Button.svelteL3-R57](diffhunk://#diff-a363cec7b0813af3b36ed98f1afc7d18d89df4c822356be440fde38910783ccaL3-R57)`)
* Updated the `children` rendering logic to handle optional content more gracefully using the safe navigation operator (`children?.()`). (`[src/lib/components/ui/button/Button.svelteL3-R57](diffhunk://#diff-a363cec7b0813af3b36ed98f1afc7d18d89df4c822356be440fde38910783ccaL3-R57)`)

### Styling Enhancements:

* Adjusted the `variantClassMap` and `sizeClassMap` to include more detailed and consistent styles, such as increased padding and font sizes. (`[src/lib/components/ui/button/Button.svelteL3-R57](diffhunk://#diff-a363cec7b0813af3b36ed98f1afc7d18d89df4c822356be440fde38910783ccaL3-R57)`)
* Changed the default button styles to use `rounded-lg` and added a smoother `transition-all` effect for better user experience. (`[src/lib/components/ui/button/Button.svelteL3-R57](diffhunk://#diff-a363cec7b0813af3b36ed98f1afc7d18d89df4c822356be440fde38910783ccaL3-R57)`)

### Updates to `Button` Usage:

* Replaced the `onpress` event with `onclick` in the example usage of the `Button` component to align with standard DOM event naming conventions. (`[src/routes/(app)/components/+page.svelteL28-R28](diffhunk://#diff-416eed06dde1b3d2b897ab9df57a48476ab411d4596e88a7b2036d2e05a7a1ddL28-R28)`)